### PR TITLE
Session Allocation

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -13,26 +13,20 @@ const DEFAULT_SETTINGS: Partial<PomodoroCanvasSettings> = {
 	longBreakLength: 25
 }
 
-enum NodeTaskStatus {
-	NotStarted,
-	Started,
-	Complete
-}
-
 enum NodeSessionStatus {
 	Inactive,
 	Active
 }
 
-interface PomodoroCanvasNode extends CanvasTextData {
+interface PomodoroCanvasNode {
 	sessionsAllocated: number;
 	sessionsCompleted: number;
-	nodeTaskStatus: NodeTaskStatus;
 	nodeSessionStatus: NodeSessionStatus;
 }
 
 export default class PomodoroCanvas extends Plugin {
 	settings: PomodoroCanvasSettings;
+	nodeMap: Map<string, PomodoroCanvasNode> = new Map<string, PomodoroCanvasNode>();
 
 	async onload() {
 		await this.loadSettings();
@@ -45,7 +39,14 @@ export default class PomodoroCanvas extends Plugin {
 				item.setTitle('+ Pomodoro session');
 				item.setIcon('star');
 				item.onClick(() => {
-					console.log(node.text)
+					if (this.nodeMap.get(node.id) === undefined) {
+						let newNode: PomodoroCanvasNode = { sessionsAllocated: 1, sessionsCompleted: 0, nodeSessionStatus: NodeSessionStatus.Inactive };
+						this.nodeMap.set(node.id, newNode);
+					} else {
+						this.nodeMap.get(node.id).sessionsAllocated++;
+					}
+
+					console.log(this.nodeMap.get(node.id).sessionsAllocated);
 				})
 			})
 
@@ -53,7 +54,9 @@ export default class PomodoroCanvas extends Plugin {
 				item.setTitle('- Pomodoro session');
 				item.setIcon('star');
 				item.onClick(() => {
-					console.log(node.text)
+					if (this.nodeMap.get(node.id) !== undefined) {
+						this.nodeMap.get(node.id).sessionsAllocated--;
+					}
 				})
 			})
 		}));

--- a/main.ts
+++ b/main.ts
@@ -13,6 +13,24 @@ const DEFAULT_SETTINGS: Partial<PomodoroCanvasSettings> = {
 	longBreakLength: 25
 }
 
+enum NodeTaskStatus {
+	NotStarted,
+	Started,
+	Complete
+}
+
+enum NodeSessionStatus {
+	Inactive,
+	Active
+}
+
+interface PomodoroCanvasNode extends CanvasTextData {
+	sessionsAllocated: number;
+	sessionsCompleted: number;
+	nodeTaskStatus: NodeTaskStatus;
+	nodeSessionStatus: NodeSessionStatus;
+}
+
 export default class PomodoroCanvas extends Plugin {
 	settings: PomodoroCanvasSettings;
 


### PR DESCRIPTION
Goal: Add a method to allocate and de-allocate pomodoro sessions on a specific node in the Canvas graph.

Solution: Using the available Index Signatures on the interfaces that define `CanvasNodeData`, I was able to insert my own interface ('PomodoroSession') into the `Node` received whenever I right-click on one and if it doesn't contain one already. Through the reference to the `MenuItem` received when right-clicking, I was able to add items to the context menu using the `addItem` function based on the status of the timer attached to a `PomodoroSession`.

**`Pause session` and `Stop session` only become visible once a session has been started:**
![image](https://github.com/user-attachments/assets/c4635219-1403-4808-9b33-984ace2182bc)
