### PR TITLE
Using Maps to keep track of nodes for future data saving

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -16,15 +16,19 @@ const DEFAULT_SETTINGS: Partial<PomodoroCanvasSettings> = {
 
 export default class PomodoroCanvas extends Plugin {
 	settings: PomodoroCanvasSettings;
+	currentTasks: Map<string, Task>;
 
 	async onload() {
 		await this.loadSettings();
 
 		this.addSettingTab(new PomodoroCanvasSettingTab(this.app, this));
 
-		// Adding items to CanvasNode context menus
+		/* 
+		 * Adding buttons to the context menu to allocate, de-allocate, start, pause, resume and stop
+		 * pomodoro sessions on a given node.
+		 */
 		this.registerEvent(this.app.workspace.on('canvas:node-menu', (menu: Menu, node: CanvasNodeData) => {
-			if (node['pomodoroSession'] === undefined) {
+			if (node['task'] === undefined) {
 				let t: Task = {
 					sessionsAllocated: 0,
 					sessionsCompleted: 0,
@@ -32,14 +36,15 @@ export default class PomodoroCanvas extends Plugin {
 					timerStatus: TimerStatus.Off
 				}
 				node['task'] = t;
+				this.currentTasks.set(node.id, t);
 			}
 
 			menu.addItem((item) => {
 				item.setTitle('+ Pomodoro session')
 					.setIcon('star')
 					.onClick(() => {
-						node['task'].sessionsAllocated++;
-						console.log(node['task'].sessionsAllocated);
+						if (this.currentTasks.has(node.id)) {
+						}
 					})
 			})
 

--- a/main.ts
+++ b/main.ts
@@ -27,6 +27,13 @@ export default class PomodoroCanvas extends Plugin {
 		 * pomodoro sessions on a given node.
 		 */
 		this.registerEvent(this.app.workspace.on('canvas:node-menu', (menu: Menu, node: CanvasNodeData) => {
+			// DEBUGGING
+			this.addContextMenuButton(menu, 'DEBUG', 'star', () => {
+				if (this.currentCanvas.has(node.id)) {
+					console.log(this.currentCanvas.get(node.id));
+				}
+			})
+
 			// Adding button to allocate sessions to task if current node is not in Map
 			if (!this.currentCanvas.has(node.id)) {
 				this.addContextMenuButton(menu, '+', 'star', () => {
@@ -39,30 +46,56 @@ export default class PomodoroCanvas extends Plugin {
 
 					this.currentCanvas.set(node.id, t);
 				})
-			} else {
-				// Add buttons to allocate & de-allocate sessions, and start timer if node is in Map
-				let t: Task = this.currentCanvas.get(node.id);
-				this.addContextMenuButton(menu, '+', 'star', () => {
-					t.sessionsAllocated++;
-				});
 
-				this.addContextMenuButton(menu, '-', 'star', () => {
-					if (t.sessionsAllocated > 0) {
-						t.sessionsAllocated--;
-					}
-				});
-
-				this.addContextMenuButton(menu, 'Start timer', 'star', () => {
-					t.timerStatus = TimerStatus.On;
-				});
+				return;
 			}
 
-			// DEBUGGING
-			this.addContextMenuButton(menu, 'DEBUG', 'star', () => {
-				if (this.currentCanvas.has(node.id)) {
-					console.log(this.currentCanvas.get(node.id));
+			// Add buttons to allocate & de-allocate sessions
+			let t: Task = this.currentCanvas.get(node.id);
+			this.addContextMenuButton(menu, '+', 'star', () => {
+				t.sessionsAllocated++;
+			});
+
+			this.addContextMenuButton(menu, '-', 'star', () => {
+				if (t.sessionsAllocated > 0) {
+					t.sessionsAllocated--;
 				}
-			})
+			});
+
+			this.addContextMenuButton(menu, 'Complete', 'star', () => {
+				t.taskStatus = TaskStatus.Complete;
+				t.timerStatus = TimerStatus.Off;
+			});
+
+			// Add buttons to manipulate timer
+			switch (t.timerStatus) {
+				case TimerStatus.Off:
+					this.addContextMenuButton(menu, 'Start', 'star', () => {
+						t.timerStatus = TimerStatus.On;
+					});
+
+					break;
+
+				case TimerStatus.On:
+					this.addContextMenuButton(menu, 'Pause', 'star', () => {
+						t.timerStatus = TimerStatus.Paused;
+					});
+					this.addContextMenuButton(menu, 'Stop', 'star', () => {
+						t.timerStatus = TimerStatus.Off;
+					});
+
+					break;
+
+				case TimerStatus.Paused:
+					this.addContextMenuButton(menu, 'Resume', 'star', () => {
+						t.timerStatus = TimerStatus.On;
+					});
+					this.addContextMenuButton(menu, 'Stop', 'star', () => {
+						t.timerStatus = TimerStatus.Off;
+					});
+
+					break;
+			}
 		}));
 	}
 

--- a/main.ts
+++ b/main.ts
@@ -27,6 +27,7 @@ export default class PomodoroCanvas extends Plugin {
 		 * pomodoro sessions on a given node.
 		 */
 		this.registerEvent(this.app.workspace.on('canvas:node-menu', (menu: Menu, node: CanvasNodeData) => {
+			// Adding button to allocate sessions to task if current node is not in Map
 			if (!this.currentCanvas.has(node.id)) {
 				this.addContextMenuButton(menu, '+', 'star', () => {
 					let t: Task = {
@@ -35,8 +36,25 @@ export default class PomodoroCanvas extends Plugin {
 						taskStatus: TaskStatus.Incomplete,
 						timerStatus: TimerStatus.Off
 					};
+
 					this.currentCanvas.set(node.id, t);
 				})
+			} else {
+				// Add buttons to allocate & de-allocate sessions, and start timer if node is in Map
+				let t: Task = this.currentCanvas.get(node.id);
+				this.addContextMenuButton(menu, '+', 'star', () => {
+					t.sessionsAllocated++;
+				});
+
+				this.addContextMenuButton(menu, '-', 'star', () => {
+					if (t.sessionsAllocated > 0) {
+						t.sessionsAllocated--;
+					}
+				});
+
+				this.addContextMenuButton(menu, 'Start timer', 'star', () => {
+					t.timerStatus = TimerStatus.On;
+				});
 			}
 
 			// DEBUGGING

--- a/main.ts
+++ b/main.ts
@@ -1,5 +1,6 @@
 import { App, Plugin, PluginSettingTab, Setting, Menu } from 'obsidian';
-import { CanvasNodeData, CanvasTextData } from 'obsidian/canvas';
+import { CanvasNodeData } from 'obsidian/canvas';
+import { Task } from 'task';
 
 interface PomodoroCanvasSettings {
 	sessionLength: number;
@@ -13,9 +14,8 @@ const DEFAULT_SETTINGS: Partial<PomodoroCanvasSettings> = {
 	longBreakLength: 25
 }
 
-enum SessionStatus {
-	NotStarted,
-	Started,
+enum NodeStatus {
+	Incomplete,
 	Complete
 }
 
@@ -25,10 +25,10 @@ enum TimerStatus {
 	Paused
 }
 
-interface PomodoroSession {
+interface Task {
 	sessionsAllocated: number;
 	sessionsCompleted: number;
-	sessionStatus: SessionStatus;
+	nodeStatus: NodeStatus;
 	timerStatus: TimerStatus;
 }
 
@@ -43,21 +43,21 @@ export default class PomodoroCanvas extends Plugin {
 		// Adding items to CanvasNode context menus
 		this.registerEvent(this.app.workspace.on('canvas:node-menu', (menu: Menu, node: CanvasNodeData) => {
 			if (node['pomodoroSession'] === undefined) {
-				let newSession: PomodoroSession = {
+				let t: Task = {
 					sessionsAllocated: 0,
 					sessionsCompleted: 0,
-					sessionStatus: SessionStatus.NotStarted,
+					nodeStatus: NodeStatus.Incomplete,
 					timerStatus: TimerStatus.Off
 				}
-				node['pomodoroSession'] = newSession;
+				node['task'] = t;
 			}
 
 			menu.addItem((item) => {
 				item.setTitle('+ Pomodoro session')
 					.setIcon('star')
 					.onClick(() => {
-						node['pomodoroSession'].sessionsAllocated++;
-						console.log(node['pomodoroSession'].sessionsAllocated);
+						node['task'].sessionsAllocated++;
+						console.log(node['task'].sessionsAllocated);
 					})
 			})
 
@@ -65,10 +65,10 @@ export default class PomodoroCanvas extends Plugin {
 				item.setTitle('- Pomodoro session')
 					.setIcon('star')
 					.onClick(() => {
-						if (node['pomodoroSession'].sessionsAllocated > node['pomodoroSession'].sessionsCompleted) {
-							node['pomodoroSession'].sessionsAllocated--;
+						if (node['task'].sessionsAllocated > node['task'].sessionsCompleted) {
+							node['task'].sessionsAllocated--;
 						}
-						console.log(node['pomodoroSession'].sessionsAllocated);
+						console.log(node['task'].sessionsAllocated);
 					})
 			})
 
@@ -76,8 +76,15 @@ export default class PomodoroCanvas extends Plugin {
 				item.setTitle('Mark complete')
 					.setIcon('star')
 					.onClick(() => {
-						node['pomodoroSession'].sessionStatus = SessionStatus.Complete;
-						node['pomodoroSession'].timerStatus = TimerStatus.Off;
+						node['task'].sessionStatus = NodeStatus.Complete;
+						node['task'].timerStatus = TimerStatus.Off;
+					})
+			})
+
+			menu.addItem((item) => {
+				item.setTitle('DEBUG')
+					.setIcon('star')
+					.onClick(() => {
 					})
 			})
 

--- a/main.ts
+++ b/main.ts
@@ -1,6 +1,6 @@
 import { App, Plugin, PluginSettingTab, Setting, Menu } from 'obsidian';
 import { CanvasNodeData } from 'obsidian/canvas';
-import { Task } from 'task';
+import { Task, TaskStatus, TimerStatus } from 'task';
 
 interface PomodoroCanvasSettings {
 	sessionLength: number;
@@ -12,24 +12,6 @@ const DEFAULT_SETTINGS: Partial<PomodoroCanvasSettings> = {
 	sessionLength: 25,
 	shortBreakLength: 25,
 	longBreakLength: 25
-}
-
-enum NodeStatus {
-	Incomplete,
-	Complete
-}
-
-enum TimerStatus {
-	Off,
-	On,
-	Paused
-}
-
-interface Task {
-	sessionsAllocated: number;
-	sessionsCompleted: number;
-	nodeStatus: NodeStatus;
-	timerStatus: TimerStatus;
 }
 
 export default class PomodoroCanvas extends Plugin {
@@ -46,7 +28,7 @@ export default class PomodoroCanvas extends Plugin {
 				let t: Task = {
 					sessionsAllocated: 0,
 					sessionsCompleted: 0,
-					nodeStatus: NodeStatus.Incomplete,
+					taskStatus: TaskStatus.Incomplete,
 					timerStatus: TimerStatus.Off
 				}
 				node['task'] = t;

--- a/task.ts
+++ b/task.ts
@@ -1,0 +1,18 @@
+enum TaskStatus {
+	Incomplete,
+	Complete
+}
+
+enum TimerStatus {
+	Off,
+	On,
+	Paused
+}
+
+export interface Task {
+	sessionsAllocated: number;
+	sessionsCompleted: number;
+	taskStatus: TaskStatus;
+	timerStatus: TimerStatus
+}
+

--- a/task.ts
+++ b/task.ts
@@ -1,9 +1,9 @@
-enum TaskStatus {
+export enum TaskStatus {
 	Incomplete,
 	Complete
 }
 
-enum TimerStatus {
+export enum TimerStatus {
 	Off,
 	On,
 	Paused


### PR DESCRIPTION
Before this update we were adding custom elements to the already existing `CanvasNode`s using the available string index specifiers left by `Canvas.d.ts` for future compatibilty. However, when considering how I was going to save the data when a user closes Obsidian and then open it up again so everything was as they left it, I realised this method wasn't going to work. 

I would have had to add the nodes to another data structure anyway and therefore, would have had to keep track of the nodes on both the data structure and on the node itself which could get very messy. Instead, I've used a `Map<string, Task>` to keep track of all the tasks in a Canvas graph.

Also as part of this rework, I've updated how we select which buttons to display in context menu depending on the state of the timer and if a node is contained in the Map or not.